### PR TITLE
Use different URL for my links

### DIFF
--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -15,7 +15,7 @@ authors:
   Ayla Pearson:
     href: https://www.poissonconsulting.ca/author/ayla-pearson/
   Kirill Müller:
-    href: https://github.com/krlmlr
+    href: https://krlmlr.info
   Nadine Hussein:
     href: https://www.poissonconsulting.ca/author/nadine-hussein/
   Evan Amies-Galonski:


### PR DESCRIPTION
I use it elsewhere, redirects to cynkra.