### PR TITLE
Add links for other developers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,5 +26,5 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.2.9000
 Config/Needs/website: poissonconsulting/poissontemplate

--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -22,3 +22,15 @@ authors:
     href: https://www.poissonconsulting.ca/author/nadine-hussein/
   Evan Amies-Galonski:
     href: https://www.poissonconsulting.ca/author/evan-amies-galonski/
+  Nicole Hill:
+    href: https://www.poissonconsulting.ca/author/nicole-hill/
+  Seb Dalgarno:
+    href: https://www.poissonconsulting.ca/author/seb-dalgarno/
+  Robyn Irvine:
+    href: https://www.poissonconsulting.ca/author/robyn-irvine/
+  Andrea Kortello:
+    href: https://www.poissonconsulting.ca/author/andrea-kortello/
+  Sarah Lyons:
+    href: https://www.poissonconsulting.ca/author/sarah-lyons/
+  Duncan Kennedy:
+    href: https://www.poissonconsulting.ca/author/duncan-kennedy/


### PR DESCRIPTION
Links were missing on some of the pkgdown websites! 
e.g., extras
<img width="209" alt="image" src="https://github.com/user-attachments/assets/e89f9638-3d3e-4db7-befe-f59cb84bd618" />
